### PR TITLE
Resolve client modules

### DIFF
--- a/src/components/ClientPathRenderer.js
+++ b/src/components/ClientPathRenderer.js
@@ -9,7 +9,7 @@ export const ClientPathRenderer = ({ element, clientPaths = [] }) => {
       const dynamicComponents = clientPaths.map(async path => {
         const { default: Comp } = await import(
           /* webpackMode: "eager" */
-          `src/pages${path}.js`
+          `src/pages${path}`
         )
 
         return Comp


### PR DESCRIPTION
The plugin should be able to match pages with file extensions other than .js. For example .jsx, .ts and .tsx. To handle this I omit the file extension from the import statement to let webpack figure that out.